### PR TITLE
Fix ThemeProvider import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To start using the components, please follow these steps:
 1. Wrap your application in a `ThemeProvider` provded by **chakra-ui**
 
 ```jsx
-import { ThemeProvider, ColorModeProvider } from "fannypack";
+import { ThemeProvider, ColorModeProvider } from "chakra-ui";
 
 const App = () => (
   <ThemeProvider>


### PR DESCRIPTION
First off, this UI kit looks awesome! Great work 👏

I noticed what I _assume_  is a typo in the README: you describe importing a `ThemeProvider` from "fannypack", likely a reference to [fannypack.style](https://fannypack.style/?theme=default). I've updated the example to import from "chakra-ui" instead :)